### PR TITLE
add doc for NERSC, including setting up jupyter kernel

### DIFF
--- a/docs/Installation/nersc.md
+++ b/docs/Installation/nersc.md
@@ -1,0 +1,38 @@
+# Installation and Setup at NERSC
+
+## Installation Steps
+
+If you do not yet have a NERSC account, please follow [these instructions](https://confluence.slac.stanford.edu/display/LSSTDESC/Getting+a+NERSC+Computing+Account).
+
+### Get the sn_pipe package
+
+Follow the typical [sn_pipe instructions](https://github.com/LSSTDESC/sn_pipe#getting-the-package-from-github)
+
+```
+ git clone https://github.com/lsstdesc/sn_pipe (master)
+or
+git clone -b <tag_name> https://github.com/lsstdesc/sn_pipe (release tag_name)
+```
+### Environment Setup
+
+CVMFS is accessible at NERSC.  Rather than using sn_pipe's release_setup.sh script, set up w_2020_15 version of lsst_sims:
+
+`source /global/common/software/lsst/cori-haswell-gcc/stack/setup_any_sims.sh w_2020_15`
+
+### Install sn_pipe
+
+```
+cd sn_pipe
+python  pip_sn_pack.py --action install --package all
+```
+
+### Running Jupyter Notebooks
+
+Rather than running jupyter at the command line, we can set up a python environment, called a jupyter kernel, which includes sn_pipe that will run in [jupyter.nersc.gov](jupyter.nersc.gov)
+
+At the command line, from within the `sn_pipe` directory, run:
+
+`./nersc/setup_nersc.sh`
+
+you only need to do this step once when first installing sn_pipe.
+

--- a/nersc/desc-sn-pipe/kernel.json
+++ b/nersc/desc-sn-pipe/kernel.json
@@ -1,0 +1,10 @@
+{
+  "argv": [
+    "/global/common/software/lsst/common/miniconda/kernels/desc-sn-pipe.sh",
+    "-f",
+    "{connection_file}"
+  ],
+  "display_name": "desc-sn-pipe",
+  "language": "python"
+}
+

--- a/nersc/setup_kernel.sh
+++ b/nersc/setup_kernel.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+DESC_SIMS_VER=w_2020_15
+
+CORISTR='cori'
+NODENAME=`uname -n`
+if [[ "$NODENAME" == *"$CORISTR"* ]]; then ON_CORI=1; fi
+
+if [[ $ON_CORI != 1 ]]; then
+    echo "This jupyter kernel set up is to be run at NERSC."
+    exit 1
+fi
+
+echo "Setting up lsst_sims " $DESC_SIMS_VER 
+INST_DIR=$PWD
+source /global/common/software/lsst/cori-haswell-gcc/stack/setup_any_sims.sh $DESC_SIMS_VER
+jupyter kernelspec install $INST_DIR/nersc/desc-sn-pipe --user
+


### PR DESCRIPTION
Providing some instructions to run `sn_pipe` at NERSC, including setting up a jupyter kernel for use in `jupyter.nersc.gov`.  Assuming DMstack `w_2020_15` for now, will likely want to revisit that in the coming weeks.